### PR TITLE
Change `define` examples for better portability

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,17 +33,17 @@ To use [] syntax (described below) you can use `INSTALL-SYNTAX!` and to disable 
 
 If a define is at the top level, it is only used to define functions, since CL doesn't have a global lexical environment for values.
 
-    (define (+2 n) (+ 2 n))
+    (define (add2 n) (+ 2 n))
 
 If define is just given a name, it sets the function value of the symbol:
 
-    (define +2 (lcurry #'+ 2))
+    (define add2 (lcurry #'+ 2))
 
 If define is nested or at the top level it can be used to define functions:
 
 Define/Lambda can take rest parameters:
 
-    (define (+2 . args) (apply #'+ 2 args))
+    (define (add2 . args) (apply #'+ 2 args))
 
 It can take optional arguments:
 


### PR DESCRIPTION
The current example of defining a function named `+2` causes trouble in
some CL implementations. These problems disappear if the function is
renamed to `add2`.

----

Here is an example session with `add2` working and `+2` not working as a definition. I would say the error thrown means that the SBCL reader is taking `+2` as a synonym of `2` and then blows up on trying to use that as a function name:

```console
$ sbcl
This is SBCL 2.1.9, an implementation of ANSI Common Lisp.
More information about SBCL is available at <http://www.sbcl.org/>.

SBCL is free software, provided as is, with absolutely no warranty.
It is mostly in the public domain; some portions are provided under
BSD-style licenses.  See the CREDITS and COPYING files in the
distribution for more information.
* (ql:quickload "schemeish")
To load "schemeish":
  Load 1 ASDF system:
    schemeish
; Loading "schemeish"

("schemeish")
* (in-package :schemeish)
#<PACKAGE "SCHEMEISH.SCHEMEISH">
* (define (add2 n) (+ 2 n))
ADD2
* (add2 33)
35
* (define (+2 n) (+ 2 n))

debugger invoked on a SIMPLE-ERROR in thread
#<THREAD "main thread" RUNNING {1004A98143}>:
  Bad thing to define: 2

Type HELP for debugger help, or (SB-EXT:EXIT) to exit from SBCL.

restarts (invokable by number or by possibly-abbreviated name):
  0: [ABORT] Exit debugger, returning to top level.

(SCHEMEISH.DEFINE::EXPAND-DEFINE-CLOSURE-OR-FUNCTION (2 N) ((+ 2 N)) SCHEMEISH.DEFINE::EXPAND-TOP-LEVEL-DEFINE-FUNCTION)
   error finding frame source: Bogus form-number: the source file has probably
                               changed too much to cope with.
   source: NIL
0] 0
```